### PR TITLE
Fix querying flow diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Defining the payload:
 #### Querying the network
 To query the network, the following flow should be implemented:
 
-![First Communication Flow](https://github.com/CF-2025-Hackathon/p2p-rag/raw/docu/documentation/querying.svg)
+![First Communication Flow](https://github.com/CF-2025-Hackathon/p2p-rag/raw/main/documentation/querying.svg)
 
 
 ### Decisions


### PR DESCRIPTION
This PR fixes the display of the querying flow diagram in the `README.md` file, as it currently points to a nonexistent branch `docu` instead of the `main` branch.